### PR TITLE
APP-5524: Bump ruby-saml dependency to 1.4.3

### DIFF
--- a/omniauth-saml.gemspec
+++ b/omniauth-saml.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = 'https://github.com/PracticallyGreen/omniauth-saml'
 
   gem.add_runtime_dependency 'omniauth', '~> 1.1'
-  gem.add_runtime_dependency 'ruby-saml', '~> 1.1', '< 1.4.3'
+  gem.add_runtime_dependency 'ruby-saml', '~> 1.1', '= 1.4.3'
 
   gem.add_development_dependency 'rspec', '~> 2.8'
   gem.add_development_dependency 'simplecov', '~> 0.6'


### PR DESCRIPTION
This is so we can validate X509SerialNumber greater than 32-bits. Before
this version, it validated that it was 32-bit. Now it validates as a string
so it'll take pretty much any value as valid according to the schema.